### PR TITLE
Cleanup ffi code

### DIFF
--- a/private/unix.rkt
+++ b/private/unix.rkt
@@ -3,19 +3,23 @@
 (require ffi/unsafe
          ffi/unsafe/define)
 (define-ffi-definer define-c (ffi-lib #f))
+(define (check val where)
+  (unless (zero? val)
+    (error where "failed: ~a" val)))
+(define _termios-pointer (_cpointer 'termios))
 
 ; int tcgetattr(int fd, struct termios *termios_p);
-(define-c tcgetattr (_fun _int _pointer -> _int))
+(define-c tcgetattr (_fun _int _termios-pointer -> (r : _int) -> (check r 'tcgetattr)))
 ; int tcsetattr(int fd, int optional_actions,
 ;               const struct termios *termios_p);
-(define-c tcsetattr (_fun _int _int _pointer -> _int))
+(define-c tcsetattr (_fun _int _int _termios-pointer -> (r : _int) -> (check r 'tcsetattr)))
 ; void cfmakeraw(struct termios *termios_p);
-(define-c cfmakeraw (_fun _pointer -> _void))
+(define-c cfmakeraw (_fun _termios-pointer -> _void))
 
-(define termios (malloc 'atomic 64))
+(define termios (cast (malloc 'atomic 36) _pointer _termios-pointer))
 
 (define (enable-raw)
-  (define termtmp (malloc 'atomic 64))
+  (define termtmp (cast (malloc 'atomic 36) _pointer _termios-pointer))
   (tcgetattr 0 termios)
   (tcgetattr 0 termtmp)
   (cfmakeraw termtmp)
@@ -24,6 +28,6 @@
 (define (disable-raw)
   (tcsetattr 0 0 termios)
   (void))
-(define-syntax-rule (with-raw commands ...) (begin (enable-raw) commands ... (disable-raw) (void)))
+(define-syntax-rule (with-raw commands ...) (begin (enable-raw) commands ... (disable-raw)))
 
 (provide enable-raw disable-raw with-raw)

--- a/private/windows.rkt
+++ b/private/windows.rkt
@@ -3,30 +3,35 @@
 (require ffi/unsafe
          ffi/unsafe/define)
 (define-ffi-definer define-c (ffi-lib #f))
+(define (check val where)
+  (when (zero? val)
+    (error where "failed: ~a ~a" val (GetLastError))))
+(define _HANDLE (_cpointer 'handle))
 
 ; HANDLE WINAPI GetStdHandle(_In_ DWORD nStdHandle);
-(define-c GetStdHandle (_fun _int -> _pointer))
+(define-c GetStdHandle (_fun _uint32 -> _HANDLE))
 ; BOOL WINAPI GetConsoleMode(_In_ HANDLE hConsoleHandle, _Out_ LPDWORD lpMode);
-(define-c GetConsoleMode (_fun _pointer _pointer -> _int))
+(define-c GetConsoleMode (_fun _HANDLE _pointer -> (r : _int) -> (check r 'GetConsoleMode)))
 ; BOOL WINAPI SetConsoleMode(_In_ HANDLE hConsoleHandle, _In_ DWORD dwMode);
-(define-c SetConsoleMode (_fun _pointer _int -> _int))
+(define-c SetConsoleMode (_fun _HANDLE _uint32 -> (r : _int) -> (check r 'SetConsoleMode)))
+; _Post_equals_last_error_ DWORD GetLastError();
+(define-c GetLastError (_fun -> _uint32))
 
-(define MAXMODE 639)
-(define LINE_INPT 2)
-(define VIRT_TERM_INPT 512)
-(define STDINPUT -10)
+(define RAW-FLAGS (- 639 4 2 1))
+(define VIRT-TERM-INPUT 512)
+(define STDINPUT 4294967286)
 (define lpMode (malloc 'atomic 8))
 
 (define (enable-raw)
   (define stdin (GetStdHandle STDINPUT))
   (GetConsoleMode stdin lpMode)
-  (define mode (bitwise-ior VIRT_TERM_INPT (bitwise-and (ptr-ref lpMode _int) (- MAXMODE LINE_INPT))))
+  (define mode (bitwise-ior VIRT-TERM-INPUT (bitwise-and (ptr-ref lpMode _uint32) RAW-FLAGS)))
   (SetConsoleMode stdin mode)
   (void))
 (define (disable-raw)
   (define stdin (GetStdHandle STDINPUT))
   (SetConsoleMode stdin (ptr-ref lpMode _int))
   (void))
-(define-syntax-rule (with-raw commands ...) (begin (enable-raw) commands ... (disable-raw) (void)))
+(define-syntax-rule (with-raw commands ...) (begin (enable-raw) commands ... (disable-raw)))
 
 (provide enable-raw disable-raw with-raw)


### PR DESCRIPTION
There are several issues with the current ffi code style.  These should be fixed:

#1 has been fixed by adding a `_HANDLE` pointer to `windows.rkt` and `_termios-pointer` to `unix.rkt`.  These are in the descriptions of the ffi functions now.

#2 has been fixed and the return values are checked to see if they are non-zero or zero when applicable.
The windows calls were failing because not all flags were set and adding these checks helped fixed that.

I am fairly convinced #3 is fixed because of section 1.6 of https://docs.racket-lang.org/foreign/intro.html.
It says using the `'atomic` keyword makes the pointer GC managed, so until further notice this issue is solved.